### PR TITLE
Add param and secret for Akka licence token

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -16,13 +16,15 @@ locals {
     }
   )
   github_access_token_name      = "/mgmt/github/access_token"
+  akka_licence_token_name       = "/mgmt/akka/licence_token"
   environment                   = terraform.workspace
   account_id                    = module.configuration.account_numbers[local.environment]
   apply_repository              = local.environment == "mgmt" ? 1 : 0
   apply_environment             = local.environment != "mgmt" ? 1 : 0
   mgmt_apply_environment        = local.environment == "mgmt" ? 1 : 0
   workflow_pat_parameter        = { name = local.github_access_token_name, description = "The GitHub workflow token", value = "to_be_manually_added", type = "SecureString", tier = "Advanced" }
-  common_parameters_repository  = [local.workflow_pat_parameter]
+  akka_licence_token_parameter  = { name = local.akka_licence_token_name, description = "Licence token for Akka", value = "to_be_manually_added", type = "SecureString" }
+  common_parameters_repository  = [local.workflow_pat_parameter, local.akka_licence_token_parameter]
   common_parameters_environment = []
   common_parameters             = local.apply_repository == 1 ? local.common_parameters_repository : local.common_parameters_environment
 }

--- a/root_github_repository.tf
+++ b/root_github_repository.tf
@@ -65,6 +65,7 @@ module "github_consignment_api_repository" {
     MANAGEMENT_ACCOUNT = data.aws_ssm_parameter.mgmt_account_number.value
     WORKFLOW_PAT       = module.common_ssm_parameters.params[local.github_access_token_name].value
     SLACK_WEBHOOK      = data.aws_ssm_parameter.slack_webhook_url.value
+    AKKA_TOKEN         = module.common_ssm_parameters.params[local.akka_licence_token_name].value
   }
 }
 


### PR DESCRIPTION
Licence token needs to be kept secret, but used in the project build

Store as ssm parameter and pass into relevant repo as a secret to be called during the Github actions as an environment variable