### PR TITLE
Allow tdr GitHub actions deploy lambda ecr access

### DIFF
--- a/modules/iam_environment_roles_policies/root.tf
+++ b/modules/iam_environment_roles_policies/root.tf
@@ -16,7 +16,7 @@ module "github_actions_deploy_lambda_policy" {
   source = "../../da-terraform-modules/iam_policy"
   name   = "TDRGithubActionsDeployLambda${title(var.environment)}"
   policy_string = templatefile("${path.module}/templates/iam_policy/deploy_lambda_github_actions.json.tpl", {
-    account_id = data.aws_caller_identity.current.account_id, environment = var.environment, region = var.region
+    account_id = data.aws_caller_identity.current.account_id, environment = var.environment, region = var.region, mgmt_account_id = var.mgmt_account_id
   })
 }
 

--- a/modules/iam_environment_roles_policies/templates/iam_policy/deploy_lambda_github_actions.json.tpl
+++ b/modules/iam_environment_roles_policies/templates/iam_policy/deploy_lambda_github_actions.json.tpl
@@ -45,6 +45,14 @@
         "arn:aws:lambda:${region}:${account_id}:function:tdr-yara-av-v2-${environment}",
         "arn:aws:s3:::tdr-backend-code-mgmt/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ],
+      "Resource": "arn:aws:ecr:eu-west-2:${mgmt_account_id}:repository/draft-metadata-validator"
     }
   ]
 }

--- a/modules/iam_environment_roles_policies/variables.tf
+++ b/modules/iam_environment_roles_policies/variables.tf
@@ -5,3 +5,5 @@ variable "region" {}
 variable "environment" {}
 
 variable "common_tags" {}
+
+variable "mgmt_account_id" {}

--- a/root_github_environment.tf
+++ b/root_github_environment.tf
@@ -338,10 +338,11 @@ module "intg_github_iam_roles_policies" {
   providers = {
     aws = aws.intg
   }
-  region      = local.region
-  account_id  = local.intg_account_id
-  environment = local.intg_environment
-  common_tags = local.common_tags
+  region          = local.region
+  account_id      = local.intg_account_id
+  environment     = local.intg_environment
+  common_tags     = local.common_tags
+  mgmt_account_id = data.aws_ssm_parameter.mgmt_account_number.value
 }
 
 module "staging_github_iam_roles_policies" {
@@ -350,10 +351,11 @@ module "staging_github_iam_roles_policies" {
   providers = {
     aws = aws.staging
   }
-  region      = local.region
-  account_id  = local.staging_account_id
-  environment = local.staging_environment
-  common_tags = local.common_tags
+  region          = local.region
+  account_id      = local.staging_account_id
+  environment     = local.staging_environment
+  common_tags     = local.common_tags
+  mgmt_account_id = data.aws_ssm_parameter.mgmt_account_number.value
 }
 
 module "prod_github_iam_roles_policies" {
@@ -362,10 +364,11 @@ module "prod_github_iam_roles_policies" {
   providers = {
     aws = aws.prod
   }
-  region      = local.region
-  account_id  = local.prod_account_id
-  environment = local.prod_environment
-  common_tags = local.common_tags
+  region          = local.region
+  account_id      = local.prod_account_id
+  environment     = local.prod_environment
+  common_tags     = local.common_tags
+  mgmt_account_id = data.aws_ssm_parameter.mgmt_account_number.value
 }
 
 module "intg_github_iam_testing_roles_policies" {


### PR DESCRIPTION
The draft-metadate-validator lambda function needs to use a docker image rather than a file.
The function has permissions to use the image but the role used to update the function to read an image must also have permissions to read the image repository