### PR TITLE
Params for new GitHub Enterprise service account

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -15,33 +15,61 @@ locals {
       "CostCentre"      = data.aws_ssm_parameter.cost_centre.value
     }
   )
-  github_access_token_name       = "/mgmt/github/access_token"
-  akka_licence_token_name        = "/mgmt/akka/licence_token"
-  environment                    = terraform.workspace
-  region                         = "eu-west-2"
-  account_id                     = module.configuration.account_numbers[local.environment]
-  intg_account_id                = module.configuration.account_numbers[local.intg_environment]
-  intg_environment               = "intg"
-  internal_buckets_kms_key_alias = module.configuration.terraform_config[local.environment]["internal_buckets_kms_key_alias"]
-  staging_account_id             = module.configuration.account_numbers[local.staging_environment]
-  staging_environment            = "staging"
-  prod_account_id                = module.configuration.account_numbers[local.prod_environment]
-  prod_environment               = "prod"
-  apply_repository               = local.environment == "mgmt" ? 1 : 0
-  apply_environment              = local.environment != "mgmt" ? 1 : 0
-  mgmt_apply_environment         = local.environment == "mgmt" ? 1 : 0
-  intg_apply                     = local.environment == "intg" ? 1 : 0
-  staging_apply                  = local.environment == "staging" ? 1 : 0
-  prod_apply                     = local.environment == "prod" ? 1 : 0
+  github_access_token_name              = "/mgmt/github/access_token"
+  github_enterprise_access_token_name   = "/mgmt/github_enterprise/access_token"
+  github_enterprise_gpg_passphrase_name = "/mgmt/github_enterprise/gpg/passphrase"
+  github_enterprise_private_key_name    = "/mgmt/github_enterprise/gpg/private_key"
+  github_enterprise_public_key_name     = "/mgmt/github_enterprise/gpg/public_key"
+  github_enterprise_key_id_name         = "/mgmt/github_enterprise/gpg/key_id"
+  akka_licence_token_name               = "/mgmt/akka/licence_token"
+  environment                           = terraform.workspace
+  region                                = "eu-west-2"
+  account_id                            = module.configuration.account_numbers[local.environment]
+  intg_account_id                       = module.configuration.account_numbers[local.intg_environment]
+  intg_environment                      = "intg"
+  internal_buckets_kms_key_alias        = module.configuration.terraform_config[local.environment]["internal_buckets_kms_key_alias"]
+  staging_account_id                    = module.configuration.account_numbers[local.staging_environment]
+  staging_environment                   = "staging"
+  prod_account_id                       = module.configuration.account_numbers[local.prod_environment]
+  prod_environment                      = "prod"
+  apply_repository                      = local.environment == "mgmt" ? 1 : 0
+  apply_environment                     = local.environment != "mgmt" ? 1 : 0
+  mgmt_apply_environment                = local.environment == "mgmt" ? 1 : 0
+  intg_apply                            = local.environment == "intg" ? 1 : 0
+  staging_apply                         = local.environment == "staging" ? 1 : 0
+  prod_apply                            = local.environment == "prod" ? 1 : 0
   workflow_pat_parameter = {
     name = local.github_access_token_name, description = "The GitHub workflow token", value = "to_be_manually_added",
+    type = "SecureString", tier = "Advanced"
+  }
+  workflow_enterprise_pat_parameter = {
+    name = local.github_enterprise_access_token_name, description = "The GitHub Enterprise workflow token", value = "to_be_manually_added",
     type = "SecureString", tier = "Advanced"
   }
   akka_licence_token_parameter = {
     name = local.akka_licence_token_name, description = "Licence token for Akka", value = "to_be_manually_added",
     type = "SecureString"
   }
-  common_parameters_repository  = [local.workflow_pat_parameter, local.akka_licence_token_parameter]
+  github_enterprise_gpg_passphrase_parameter = {
+    name = local.github_enterprise_gpg_passphrase_name, description = "GitHub Enterprise GPG passphase for key", value = "to_be_manually_added",
+    type = "SecureString"
+  }
+  github_enterprise_private_key_parameter = {
+    name = local.github_enterprise_private_key_name, description = "GitHub Enterprise GPG private key", value = "to_be_manually_added",
+    type = "SecureString"
+  }
+  github_enterprise_public_key_parameter = {
+    name = local.github_enterprise_public_key_name, description = "GitHub Enterprise GPG public key", value = "to_be_manually_added",
+    type = "SecureString"
+  }
+  github_enterprise_key_id_parameter = {
+    name = local.github_enterprise_key_id_name, description = "GitHub Enterprise GPG key id", value = "to_be_manually_added",
+    type = "SecureString"
+  }
+  common_parameters_repository = [
+    local.workflow_pat_parameter, local.akka_licence_token_parameter, local.workflow_enterprise_pat_parameter, local.github_enterprise_gpg_passphrase_parameter,
+    local.github_enterprise_key_id_parameter, local.github_enterprise_private_key_parameter, local.github_enterprise_public_key_parameter
+  ]
   common_parameters_environment = []
   common_parameters             = local.apply_repository == 1 ? local.common_parameters_repository : local.common_parameters_environment
 }


### PR DESCRIPTION
As part of the migration to GitHub Enterprise a new Digital Archiving service account has been created with SSO enforced

Add new SSM params to hold the relevant information to allow TDR GitHub actions to use the new service account

Existing service account SSM params to remain in place until migration complete and the existing GitHub service account is retired